### PR TITLE
Fix: Prevent InvalidCastException in SendCollector (Von Neumann encounter)

### DIFF
--- a/Kerberos/Sots/Encounters/VonNeumann.cs
+++ b/Kerberos/Sots/Encounters/VonNeumann.cs
@@ -587,102 +587,108 @@ namespace Kerberos.Sots.Encounters
 			}
 		}
 
-		public void SendCollector(GameSession game, ref VonNeumannInfo vi, bool forceHomeworldAttack = false)
-		{
-			List<FleetInfo> list = game.GameDatabase.GetFleetInfosByPlayerID(this.PlayerId, FleetType.FL_NORMAL).ToList<FleetInfo>();
-			VonNeumannGlobalData globalVonNeumannData = game.AssetDatabase.GlobalVonNeumannData;
-			FleetInfo fleetInfo = VonNeumann.GetCollectorFleetInfo(list);
-			if (fleetInfo == null)
-			{
-				DesignInfo designInfo = game.GameDatabase.GetDesignInfo(VonNeumann.StaticShipDesigns[VonNeumann.VonNeumannShipDesigns.CollectorMothership].DesignId);
-				if ((double)vi.Resources > (double)designInfo.ProductionCost / (double)game.AssetDatabase.DefaultStratModifiers[StratModifiers.OverharvestModifier])
-				{
-					vi.Resources -= (int)((double)designInfo.ProductionCost / (double)game.AssetDatabase.DefaultStratModifiers[StratModifiers.OverharvestModifier]);
-					vi.FleetId = new int?(game.GameDatabase.InsertFleet(this.PlayerId, 0, vi.SystemId, vi.SystemId, "Von Neumann Collector", FleetType.FL_NORMAL));
-					game.GameDatabase.InsertShip(vi.FleetId.Value, VonNeumann.StaticShipDesigns[VonNeumann.VonNeumannShipDesigns.CollectorMothership].DesignId, null, (ShipParams)0, new int?(), 0);
-					fleetInfo = game.GameDatabase.GetFleetInfo(vi.FleetId.Value);
-				}
-				else
-				{
-					vi.Resources = 0;
-					vi.FleetId = new int?(game.GameDatabase.InsertFleet(this.PlayerId, 0, vi.SystemId, vi.SystemId, "Von Neumann Collector", FleetType.FL_NORMAL));
-					game.GameDatabase.InsertShip(vi.FleetId.Value, VonNeumann.StaticShipDesigns[VonNeumann.VonNeumannShipDesigns.CollectorMothership].DesignId, null, (ShipParams)0, new int?(), 0);
-					fleetInfo = game.GameDatabase.GetFleetInfo(vi.FleetId.Value);
-				}
-				int sysId = vi.LastCollectionSystem;
-				if (!vi.TargetInfos.Any<VonNeumannTargetInfo>((Func<VonNeumannTargetInfo, bool>)(x => x.SystemId == sysId)) && sysId != 0)
-					vi.TargetInfos.Add(new VonNeumannTargetInfo()
-					{
-						SystemId = sysId,
-						ThreatLevel = 1
-					});
-			}
-			else if (vi.LastCollectionSystem != 0)
-			{
-				foreach (int num1 in game.GameDatabase.GetStarSystemOrbitalObjectIDs(fleetInfo.SystemID).ToList<int>())
-				{
-					PlanetInfo planetInfo = game.GameDatabase.GetPlanetInfo(num1);
-					LargeAsteroidInfo largeAsteroidInfo = game.GameDatabase.GetLargeAsteroidInfo(num1);
-					int num2 = globalVonNeumannData.SalvageCapacity - vi.ResourcesCollectedLastTurn;
-					if (planetInfo != null)
-					{
-						if (planetInfo.Resources > num2)
-						{
-							planetInfo.Resources -= num2;
-							vi.ResourcesCollectedLastTurn = globalVonNeumannData.SalvageCapacity;
-							break;
-						}
-						vi.ResourcesCollectedLastTurn += planetInfo.Resources;
-						planetInfo.Resources = 0;
-						game.GameDatabase.UpdatePlanet(planetInfo);
-					}
-					else if (largeAsteroidInfo != null)
-					{
-						if (largeAsteroidInfo.Resources > num2)
-						{
-							largeAsteroidInfo.Resources -= num2;
-							vi.ResourcesCollectedLastTurn = globalVonNeumannData.SalvageCapacity;
-							break;
-						}
-						vi.ResourcesCollectedLastTurn += largeAsteroidInfo.Resources;
-						largeAsteroidInfo.Resources = 0;
-						game.GameDatabase.UpdateLargeAsteroidInfo(largeAsteroidInfo);
-					}
-				}
-				vi.Resources += vi.ResourcesCollectedLastTurn;
-				fleetInfo.SystemID = vi.SystemId;
-				game.GameDatabase.UpdateFleetLocation(fleetInfo.ID, fleetInfo.SystemID, new int?());
-			}
-			vi.LastCollectionSystem = 0;
-			int turnCount = game.GameDatabase.GetTurnCount();
-			if (fleetInfo == null || turnCount <= vi.LastCollectionTurn + globalVonNeumannData.SalvageCycle && !forceHomeworldAttack && !this.ForceVonNeumannAttackCycle)
-				return;
-			vi.LastCollectionTurn = turnCount;
-			List<int> intList = new List<int>();
-			foreach (int num in game.GameDatabase.GetStarSystemIDs().ToList<int>())
-			{
-				int system = num;
-				if (!vi.TargetInfos.Any<VonNeumannTargetInfo>((Func<VonNeumannTargetInfo, bool>)(x => x.SystemId == system)))
-				{
-					int? systemOwningPlayer = game.GameDatabase.GetSystemOwningPlayer(system);
-					if (systemOwningPlayer.HasValue)
-					{
-						Player playerObject = game.GetPlayerObject(systemOwningPlayer.Value);
-						if (playerObject == null || playerObject.IsAI())
-							continue;
-					}
-					intList.Add(system);
-				}
-			}
-			if (intList.Count <= 0)
-				return;
-			fleetInfo.SystemID = forceHomeworldAttack || this.ForceVonNeumannAttackCycle ? game.GameDatabase.GetOrbitalObjectInfo(game.GameDatabase.GetPlayerInfo(game.LocalPlayer.ID).Homeworld.Value).StarSystemID : intList[App.GetSafeRandom().Next(intList.Count)];
-			vi.FleetId = new int?(fleetInfo.ID);
-			vi.LastCollectionSystem = fleetInfo.SystemID;
-			game.GameDatabase.UpdateFleetLocation(fleetInfo.ID, fleetInfo.SystemID, new int?());
-		}
+        public void SendCollector(GameSession game, ref VonNeumannInfo vi, bool forceHomeworldAttack = false)
+        {
 
-		public void HandleHomeSystemDefeated(App app, FleetInfo fi, List<int> attackingPlayers)
+            List<FleetInfo> list = game.GameDatabase.GetFleetInfosByPlayerID(this.PlayerId, FleetType.FL_NORMAL).ToList<FleetInfo>();
+            VonNeumannGlobalData globalVonNeumannData = game.AssetDatabase.GlobalVonNeumannData;
+            FleetInfo fleetInfo = VonNeumann.GetCollectorFleetInfo(list);
+
+            if (fleetInfo == null)
+            {
+
+                DesignInfo designInfo = game.GameDatabase.GetDesignInfo(VonNeumann.StaticShipDesigns[VonNeumann.VonNeumannShipDesigns.CollectorMothership].DesignId);
+                ///changed from (double) to Convert.ToDouble(...) to avoid crash since OverharvestModifier is Float
+                if (Convert.ToDouble(vi.Resources) > Convert.ToDouble(designInfo.ProductionCost) / Convert.ToDouble(game.AssetDatabase.DefaultStratModifiers[StratModifiers.OverharvestModifier]))
+                {
+
+                    vi.Resources -= (int)(Convert.ToDouble(designInfo.ProductionCost) / Convert.ToDouble(game.AssetDatabase.DefaultStratModifiers[StratModifiers.OverharvestModifier]));
+                    vi.FleetId = new int?(game.GameDatabase.InsertFleet(this.PlayerId, 0, vi.SystemId, vi.SystemId, "Von Neumann Collector", FleetType.FL_NORMAL));
+                    game.GameDatabase.InsertShip(vi.FleetId.Value, VonNeumann.StaticShipDesigns[VonNeumann.VonNeumannShipDesigns.CollectorMothership].DesignId, null, (ShipParams)0, new int?(), 0);
+                    fleetInfo = game.GameDatabase.GetFleetInfo(vi.FleetId.Value);
+                }
+                else
+                {
+
+                    vi.Resources = 0;
+                    vi.FleetId = new int?(game.GameDatabase.InsertFleet(this.PlayerId, 0, vi.SystemId, vi.SystemId, "Von Neumann Collector", FleetType.FL_NORMAL));
+                    game.GameDatabase.InsertShip(vi.FleetId.Value, VonNeumann.StaticShipDesigns[VonNeumann.VonNeumannShipDesigns.CollectorMothership].DesignId, null, (ShipParams)0, new int?(), 0);
+                    fleetInfo = game.GameDatabase.GetFleetInfo(vi.FleetId.Value);
+                }
+                int sysId = vi.LastCollectionSystem;
+                if (!vi.TargetInfos.Any<VonNeumannTargetInfo>((Func<VonNeumannTargetInfo, bool>)(x => x.SystemId == sysId)) && sysId != 0)
+                    vi.TargetInfos.Add(new VonNeumannTargetInfo()
+                    {
+                        SystemId = sysId,
+                        ThreatLevel = 1
+                    });
+            }
+            else if (vi.LastCollectionSystem != 0)
+            {
+                foreach (int num1 in game.GameDatabase.GetStarSystemOrbitalObjectIDs(fleetInfo.SystemID).ToList<int>())
+                {
+                    PlanetInfo planetInfo = game.GameDatabase.GetPlanetInfo(num1);
+                    LargeAsteroidInfo largeAsteroidInfo = game.GameDatabase.GetLargeAsteroidInfo(num1);
+                    int num2 = globalVonNeumannData.SalvageCapacity - vi.ResourcesCollectedLastTurn;
+                    if (planetInfo != null)
+                    {
+                        if (planetInfo.Resources > num2)
+                        {
+                            planetInfo.Resources -= num2;
+                            vi.ResourcesCollectedLastTurn = globalVonNeumannData.SalvageCapacity;
+                            break;
+                        }
+                        vi.ResourcesCollectedLastTurn += planetInfo.Resources;
+                        planetInfo.Resources = 0;
+                        game.GameDatabase.UpdatePlanet(planetInfo);
+                    }
+                    else if (largeAsteroidInfo != null)
+                    {
+                        if (largeAsteroidInfo.Resources > num2)
+                        {
+                            largeAsteroidInfo.Resources -= num2;
+                            vi.ResourcesCollectedLastTurn = globalVonNeumannData.SalvageCapacity;
+                            break;
+                        }
+                        vi.ResourcesCollectedLastTurn += largeAsteroidInfo.Resources;
+                        largeAsteroidInfo.Resources = 0;
+                        game.GameDatabase.UpdateLargeAsteroidInfo(largeAsteroidInfo);
+                    }
+                }
+                vi.Resources += vi.ResourcesCollectedLastTurn;
+                fleetInfo.SystemID = vi.SystemId;
+                game.GameDatabase.UpdateFleetLocation(fleetInfo.ID, fleetInfo.SystemID, new int?());
+            }
+            vi.LastCollectionSystem = 0;
+            int turnCount = game.GameDatabase.GetTurnCount();
+            if (fleetInfo == null || turnCount <= vi.LastCollectionTurn + globalVonNeumannData.SalvageCycle && !forceHomeworldAttack && !this.ForceVonNeumannAttackCycle)
+                return;
+            vi.LastCollectionTurn = turnCount;
+            List<int> intList = new List<int>();
+            foreach (int num in game.GameDatabase.GetStarSystemIDs().ToList<int>())
+            {
+                int system = num;
+                if (!vi.TargetInfos.Any<VonNeumannTargetInfo>((Func<VonNeumannTargetInfo, bool>)(x => x.SystemId == system)))
+                {
+                    int? systemOwningPlayer = game.GameDatabase.GetSystemOwningPlayer(system);
+                    if (systemOwningPlayer.HasValue)
+                    {
+                        Player playerObject = game.GetPlayerObject(systemOwningPlayer.Value);
+                        if (playerObject == null || playerObject.IsAI())
+                            continue;
+                    }
+                    intList.Add(system);
+                }
+            }
+            if (intList.Count <= 0)
+                return;
+            fleetInfo.SystemID = forceHomeworldAttack || this.ForceVonNeumannAttackCycle ? game.GameDatabase.GetOrbitalObjectInfo(game.GameDatabase.GetPlayerInfo(game.LocalPlayer.ID).Homeworld.Value).StarSystemID : intList[App.GetSafeRandom().Next(intList.Count)];
+            vi.FleetId = new int?(fleetInfo.ID);
+            vi.LastCollectionSystem = fleetInfo.SystemID;
+            game.GameDatabase.UpdateFleetLocation(fleetInfo.ID, fleetInfo.SystemID, new int?());
+        }
+
+        public void HandleHomeSystemDefeated(App app, FleetInfo fi, List<int> attackingPlayers)
 		{
 			VonNeumannInfo vonNeumannInfo = app.Game.GameDatabase.GetVonNeumannInfos().FirstOrDefault<VonNeumannInfo>((Func<VonNeumannInfo, bool>)(x =>
 		   {


### PR DESCRIPTION
Hey not sure if you still want to touch the Patch, it has been left alone for a bit ;)

This fixes a crash caused by an invalid cast in the metodh SendCollector

The issue was due to `StratModifiers.OverharvestModifier` being a `float`, which caused `(double)vi.Resources > (double)design.ProductionCost / (double)float` to throw an error.

Log Evidence (i removed my custom log calls afterwards):

T (2025/06/19 23:22:05) [game] [VN] ProductionCost raw type: System.Int32
T (2025/06/19 23:22:05) [game] [VN] ProductionCost value: 1000
T (2025/06/19 23:22:05) [game] [VN] vi.Resources raw type: System.Int32
T (2025/06/19 23:22:05) [game] [VN] vi.Resources value: 100
T (2025/06/19 23:22:05) [game] [VN] StratModifiers.OverharvestModifier raw type: System.Single
T (2025/06/19 23:22:05) [game] [VN] StratModifiers.OverharvestModifier value: 10

Fix replaces the implicit cast with a safe call to `Convert.ToDouble(...)` - for consitency i changed all casts of `(double)` to `Convert.ToDouble(...)`

Sorry for the messed up commit, some end of line stupitidy, actual changes are just (double) to Convert.ToDouble() inside the SendCollector method.

Game progressed to the next turn for me after the fix

before the fix i got the following Trace
<details> <summary>Click to expand full stack trace</summary>
W (2025/06/19 23:22:05) [game] System.InvalidCastException: The specified cast is not valid

   bei Kerberos.Sots.Encounters.VonNeumann.SendCollector(GameSession game, VonNeumannInfo& vi, Boolean forceHomeworldAttack) in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\Encounters\VonNeumann.cs:Zeile 626.

   bei Kerberos.Sots.Encounters.VonNeumann.UpdateTurn(GameSession game, Int32 id) in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\Encounters\VonNeumann.cs:Zeile 377.

   bei Kerberos.Sots.Strategy.ScriptModules.UpdateEasterEggs(GameSession game) in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\Strategy\ScriptModules.cs:Zeile 144.

   bei Kerberos.Sots.Strategy.GameSession.Phase4_Combat() in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\Strategy\GameSession.cs:Zeile 5997.

   bei Kerberos.Sots.Strategy.GameSession.Phase3_ReactionMovement() in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\Strategy\GameSession.cs:Zeile 5982.

   bei Kerberos.Sots.Strategy.GameSession.ProcessMidTurn() in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\Strategy\GameSession.cs:Zeile 1458.

   bei Kerberos.Sots.Strategy.GameSession.ProcessEndTurn() in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\Strategy\GameSession.cs:Zeile 1441.

   bei Kerberos.Sots.App.EndTurn() in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\App.cs:Zeile 1687.

   bei Kerberos.Sots.Engine.GameUICommands.<>c__DisplayClass3_0.<.ctor>b__0() in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\Engine\GameUICommands.cs:Zeile 23.

   bei Kerberos.Sots.Engine.UICommand.Trigger() in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\Engine\UICommand.cs:Zeile 73.

   bei Kerberos.Sots.GameStates.StarMapState.EndTurn(Boolean forceConfirm) in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\GameStates\StarMapState.cs:Zeile 1708.

   bei Kerberos.Sots.GameStates.StarMapState.UICommChannel_OnPanelMessage(String panelName, String msgType, String[] msgParams) in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\GameStates\StarMapState.cs:Zeile 1633.

   bei Kerberos.Sots.GameState.UICommChannel_PanelMessage(String panelName, String msgType, String[] msgParams) in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\GameState.cs:Zeile 151.

   bei Kerberos.Sots.Engine.UIEventPanelMessage.Invoke(String panelName, String msgType, String[] msgParams)

   bei Kerberos.Sots.Engine.UICommChannel.CloseDialog(Dialog dialog, Boolean dispose) in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\Engine\UICommChannel.cs:Zeile 152.

   bei Kerberos.Sots.UI.GenericQuestionDialog.OnPanelMessage(String panelName, String msgType, String[] msgParams) in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\UI\GenericQuestionDialog.cs:Zeile 26.

   bei Kerberos.Sots.UI.Dialog.UICommChannel_PanelMessage(String panelName, String msgType, String[] msgParams) in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\UI\Dialog.cs:Zeile 37.

   bei Kerberos.Sots.Engine.UIEventPanelMessage.Invoke(String panelName, String msgType, String[] msgParams)

   bei Kerberos.Sots.Engine.UICommChannel.ProcessPanelMessage(String[] subStrings) in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\Engine\UICommChannel.cs:Zeile 752.

   bei Kerberos.Sots.Engine.UICommChannel.ProcessEngineMessage(String engMsg) in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\Engine\UICommChannel.cs:Zeile 710.

   bei Kerberos.Sots.Engine.UICommChannel.Update() in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\Engine\UICommChannel.cs:Zeile 91.

   bei Kerberos.Sots.App.Update() in C:\Users\Stewie\source\repos\SOTSII-SOS-master\Kerberos\Sots\App.cs:Zeile 1864.
   </details>